### PR TITLE
Fixing Certificate Dialog View

### DIFF
--- a/Vault/Explorer/PropertyObjectSecret.cs
+++ b/Vault/Explorer/PropertyObjectSecret.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Vault.Explorer
             TagItem oldTag = this.Tags.GetOrNull(newTag);
 
             // Don't add the SecretKind to a secret that doesn't have any custom tags
-            if ((null == _customTags) || (_customTags.Count == 0)) return;
+            if (null == _customTags) return;
             
             // Don't add the SecretKind to a secret that's defaulted to Custom
             if (sk.Alias == "Custom" && !this.Tags.Contains(newTag)) return;

--- a/Vault/Explorer/SecretDialog.cs
+++ b/Vault/Explorer/SecretDialog.cs
@@ -266,6 +266,7 @@ namespace Microsoft.Vault.Explorer
             _certificateObj = cvo;
             if (_certificateObj != null)
             {
+                uxTextBoxValue.ReadOnly = false;
                 _certificateObj.FillTagsAndExpiration(PropertyObject);
                 uxTextBoxValue.Text = _certificateObj.ToValue(PropertyObject.SecretKind.CertificateFormat);
                 uxTextBoxValue.Refresh();


### PR DESCRIPTION
Addressing Certificate Dialog bug not allowing certificates to be saved in different formats.